### PR TITLE
Expect call to InitExporter any number of times

### DIFF
--- a/internal/entrypoint/run_test.go
+++ b/internal/entrypoint/run_test.go
@@ -230,7 +230,7 @@ func Test_Run(t *testing.T) {
 			entrypoint.ConfigValidatorFunc = noCheckConfig
 
 			e := exportermocks.NewMockOtlexporter(ctrl)
-			e.EXPECT().InitExporter(gomock.Any(), gomock.Any()).Return(nil)
+			e.EXPECT().InitExporter(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 			e.EXPECT().StopExporter().Return(nil)
 
 			svc := metrics.NewMockService(ctrl)


### PR DESCRIPTION
# Description
Fixes a race condition with the csm-metrics-powerstore unit tests. The call to InitExporter may be called either 0 or 1 times depending if the go routine is created.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/113 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Executed unit tests with a high count to verify the error no longer exists with the test
