### PR TITLE
Configure ReadHeaderTimeout in the http.Server

### DIFF
--- a/cmd/metrics-powerstore/main.go
+++ b/cmd/metrics-powerstore/main.go
@@ -163,8 +163,9 @@ func main() {
 			return fmt.Sprintf("%d", runtime.NumGoroutine())
 		}))
 		s := http.Server{
-			Addr:    fmt.Sprintf(":%d", bindPort),
-			Handler: http.DefaultServeMux,
+			Addr:              fmt.Sprintf(":%d", bindPort),
+			Handler:           http.DefaultServeMux,
+			ReadHeaderTimeout: 5 * time.Second,
 		}
 		if err := s.ListenAndServeTLS(certFile, keyFile); err != nil {
 			logger.WithError(err).Error("debug listener closed")


### PR DESCRIPTION
# Description
This PR addresses a new rule added to gosec that detects if ReadHeaderTimeout is configured in the http.Server. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/243 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit Test

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [ ] Yes
- [x] No
