### PR TITLE
add PV/PVC namespace mapping

### DIFF
--- a/internal/service/metrics.go
+++ b/internal/service/metrics.go
@@ -136,6 +136,8 @@ func (mw *MetricsWrapper) Record(ctx context.Context, meta interface{},
 			attribute.String("VolumeID", v.ID),
 			attribute.String("ArrayID", v.ArrayID),
 			attribute.String("PersistentVolumeName", v.PersistentVolumeName),
+			attribute.String("PersistentVolumeClaimName", v.PersistentVolumeClaimName),
+			attribute.String("Namespace", v.Namespace),
 			attribute.String("PlotWithMean", "No"),
 		}
 	default:
@@ -508,6 +510,8 @@ func (mw *MetricsWrapper) RecordFileSystemMetrics(ctx context.Context, meta inte
 			attribute.String("FileSystemID", v.ID),
 			attribute.String("ArrayID", v.ArrayID),
 			attribute.String("PersistentVolumeName", v.PersistentVolumeName),
+			attribute.String("PersistentVolumeClaimName", v.PersistentVolumeClaimName),
+			attribute.String("Namespace", v.Namespace),
 			attribute.String("StorageClass", v.StorageClass),
 			attribute.String("PlotWithMean", "No"),
 		}

--- a/internal/service/metrics_test.go
+++ b/internal/service/metrics_test.go
@@ -772,16 +772,25 @@ func Test_StorageClassSpace_Metrics_Record(t *testing.T) {
 }
 func Test_Volume_Metrics_Label_Update(t *testing.T) {
 	metaFirst := &service.VolumeMeta{
-		ID: "123",
+		ID:                        "123",
+		PersistentVolumeName:      "pvol0",
+		PersistentVolumeClaimName: "pvc0",
+		Namespace:                 "namespace0",
 	}
 
 	metaSecond := &service.VolumeMeta{
-		ID: "123",
+		ID:                        "123",
+		PersistentVolumeName:      "pvol0",
+		PersistentVolumeClaimName: "pvc0",
+		Namespace:                 "namespace0",
 	}
 
 	expectedLables := []attribute.KeyValue{
 		attribute.String("VolumeID", metaSecond.ID),
 		attribute.String("PlotWithMean", "No"),
+		attribute.String("PersistentVolumeName", metaSecond.PersistentVolumeName),
+		attribute.String("PersistentVolumeClaimName", metaSecond.PersistentVolumeClaimName),
+		attribute.String("Namespace", metaSecond.Namespace),
 	}
 
 	ctrl := gomock.NewController(t)
@@ -1120,16 +1129,25 @@ func Test_StrorageClass_Space_Metrics_Label_Update(t *testing.T) {
 
 func Test_FileSystem_Metrics_Label_Update(t *testing.T) {
 	metaFirst := &service.VolumeMeta{
-		ID: "123",
+		ID:                        "123",
+		PersistentVolumeName:      "pvol0",
+		PersistentVolumeClaimName: "pvc0",
+		Namespace:                 "namespace0",
 	}
 
 	metaSecond := &service.VolumeMeta{
-		ID: "123",
+		ID:                        "123",
+		PersistentVolumeName:      "pvol0",
+		PersistentVolumeClaimName: "pvc0",
+		Namespace:                 "namespace0",
 	}
 
 	expectedLables := []attribute.KeyValue{
 		attribute.String("FileSystemID", metaSecond.ID),
 		attribute.String("PlotWithMean", "No"),
+		attribute.String("PersistentVolumeName", metaSecond.PersistentVolumeName),
+		attribute.String("PersistentVolumeClaimName", metaSecond.PersistentVolumeClaimName),
+		attribute.String("Namespace", metaSecond.Namespace),
 	}
 
 	ctrl := gomock.NewController(t)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -181,9 +181,11 @@ func (s *PowerStoreService) gatherVolumeMetrics(ctx context.Context, volumes <-c
 				}
 
 				volumeMeta := &VolumeMeta{
-					ID:                   volumeID,
-					PersistentVolumeName: volume.PersistentVolume,
-					ArrayID:              arrayID,
+					ID:                        volumeID,
+					PersistentVolumeName:      volume.PersistentVolume,
+					PersistentVolumeClaimName: volume.VolumeClaimName,
+					Namespace:                 volume.Namespace,
+					ArrayID:                   arrayID,
 				}
 
 				goPowerStoreClient, err := s.getPowerStoreClient(ctx, arrayID)
@@ -795,10 +797,12 @@ func (s *PowerStoreService) gatherFileSystemMetrics(ctx context.Context, volumes
 				}
 
 				volumeMeta := &VolumeMeta{
-					ID:                   volumeID,
-					PersistentVolumeName: volume.PersistentVolume,
-					ArrayID:              arrayID,
-					StorageClass:         volume.StorageClass,
+					ID:                        volumeID,
+					PersistentVolumeName:      volume.PersistentVolume,
+					PersistentVolumeClaimName: volume.VolumeClaimName,
+					Namespace:                 volume.Namespace,
+					ArrayID:                   arrayID,
+					StorageClass:              volume.StorageClass,
 				}
 
 				goPowerStoreClient, err := s.getPowerStoreClient(ctx, arrayID)

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -14,10 +14,12 @@ import (
 
 // VolumeMeta is the details of a volume in an SDC
 type VolumeMeta struct {
-	ID                   string
-	PersistentVolumeName string
-	ArrayID              string
-	StorageClass         string
+	ID                        string
+	PersistentVolumeName      string
+	PersistentVolumeClaimName string
+	Namespace                 string
+	ArrayID                   string
+	StorageClass              string
 }
 
 // SpaceVolumeMeta is the details of a volume in an SDC


### PR DESCRIPTION
# Description
PowerStore: added PV/PVC namespace mapping in 'PowerStore Volume IO metrics' and 'PowerStore Filesystem IO Metrics'

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/204 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have inspected the Grafana dashboards to verify the data is displayed properly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Test A
UT:
![image](https://user-images.githubusercontent.com/63342088/179488505-609b5506-0d62-4193-92bc-156b9443d561.png)

- [x] Test B
Manual:
![image](https://user-images.githubusercontent.com/63342088/179488594-cf9a92f2-f28b-45c6-891a-f123fa2123b1.png)
![image](https://user-images.githubusercontent.com/63342088/179488636-beba2579-5d1d-4ae0-be92-f4897a4a2222.png)


# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [x] Yes
- [ ] No
