### PR TITLE
handle segmentation violation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,25 +6,27 @@
 # These are the default owners for the code and will
 # be requested for review when someone opens a pull request.
 #
-# Sean Gallacher (gallacher)
-# Trevor Dawe (tdawe)
+# Aaron Tye (atye)
 # Alexander Hoppe (hoppea2)
 # Alik Saring (alikdell)
-# Aaron Tye (atye)
-# Florian Coulombel (coulof)
-# Shayna Finocchiaro (shaynafinocchiaro)
-# Sharmila Ramamoorthy (sharmilarama)
-# Evgeny Uglov (EvgenyUglov)
-# Bowen Jiang (bjiang27)
-# Tao He (taohe1012)
-# Peter Cao (P-Cao)
-# Yiming Bao (baoy1)
-# Yian Zong  (YianZong)
-# Forrest Xia (forrestxia)
-# Don Khan (donatwork)
-# Harsha Yalamanchili (harshaatdell)
 # AnandatDell (anandrajak1)
+# Bowen Jiang (bjiang27)
+# Chiman Jain (chimanjain)
+# Don Khan (donatwork)
+# Evgeny Uglov (EvgenyUglov)
+# Florian Coulombel (coulof)
+# Harish H  (HarishH-DELL)
+# Harsha Yalamanchili (harshaatdell)
+# Nitesh Rewatkar (nitesh3108)
+# Rajendra Indukuri (rajendraindukuri)
+# Sean Gallacher (gallacher)
+# Shefali Malhotra (shefali-malhotra)
+# Sharmila Ramamoorthy (sharmilarama)
+# Shayna Finocchiaro (shaynafinocchiaro)
+# Spandita Panigrahi (panigs7)
+# Trevor Dawe (tdawe)
 
 
 # for all files:
-* @gallacher @tdawe @alikdell @atye @hoppea2 @coulof @shaynafinocchiaro @sharmilarama @EvgenyUglov @bjiang27 @taohe1012 @P-Cao @baoy1 @YianZong @forrestxia @donatwork @harshaatdell @anandrajak1
+* @atye @hoppea2 @alikdell @anandrajak1 @bjiang27 @chimanjain @donatwork @EvgenyUglov @coulof @HarishH-DELL @harshaatdell @nitesh3108 @rajendraindukuri @gallacher @shefali-malhotra @sharmilarama @shaynafinocchiaro @panigs7 @tdawe
+

--- a/internal/k8s/volume_finder.go
+++ b/internal/k8s/volume_finder.go
@@ -72,6 +72,13 @@ func (f VolumeFinder) GetPersistentVolumes(ctx context.Context) ([]VolumeInfo, e
 			f.Logger.Debugf("The PV, %s , is not provisioned by a CSI driver\n", volume.GetName())
 			continue
 		}
+
+		// Check added to skip PV s which do not have any PVC s
+		if volume.Spec.ClaimRef == nil {
+			f.Logger.Debugf("The PV, %s , do not have a claim \n", volume.GetName())
+			continue
+		}
+
 		if contains(f.DriverNames, volume.Spec.CSI.Driver) {
 			capacity := volume.Spec.Capacity[v1.ResourceStorage]
 			claim := volume.Spec.ClaimRef

--- a/internal/k8s/volume_finder_test.go
+++ b/internal/k8s/volume_finder_test.go
@@ -326,6 +326,82 @@ func Test_K8sPersistentVolumeFinder(t *testing.T) {
 				},
 			})), ctrl
 		},
+		"success filtering the persistent volumes which do not have claims": func(*testing.T) (k8s.VolumeFinder, []checkFn, *gomock.Controller) {
+			ctrl := gomock.NewController(t)
+			api := mocks.NewMockVolumeGetter(ctrl)
+
+			t1, err := time.Parse(time.RFC3339, "2020-07-28T20:00:00+00:00")
+			assert.Nil(t, err)
+
+			volumes := &corev1.PersistentVolumeList{
+				Items: []corev1.PersistentVolume{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "persistent-volume-name",
+							CreationTimestamp: metav1.Time{Time: t1},
+						},
+						Spec: corev1.PersistentVolumeSpec{
+							Capacity: map[corev1.ResourceName]resource.Quantity{
+								v1.ResourceStorage: resource.MustParse("16Gi"),
+							},
+							PersistentVolumeSource: corev1.PersistentVolumeSource{
+								CSI: &corev1.CSIPersistentVolumeSource{
+									Driver: "csi-powerstore.dellemc.com",
+									VolumeAttributes: map[string]string{
+										"arrayIP": "127.0.0.1",
+									},
+									VolumeHandle: "storage-system-volume-id/127.0.0.1/protocol",
+								},
+							},
+							ClaimRef: &corev1.ObjectReference{
+								Name:      "pvc-name",
+								Namespace: "namespace-1",
+								UID:       "pvc-uid",
+							},
+							StorageClassName: "storage-class-name",
+						},
+						Status: corev1.PersistentVolumeStatus{
+							Phase: "Bound",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "persistent-volume-name",
+							CreationTimestamp: metav1.Time{Time: t1},
+						},
+						Spec: corev1.PersistentVolumeSpec{
+							Capacity: map[corev1.ResourceName]resource.Quantity{
+								v1.ResourceStorage: resource.MustParse("16Gi"),
+							},
+							PersistentVolumeSource: corev1.PersistentVolumeSource{},
+							ClaimRef:               nil,
+							StorageClassName:       "storage-class-name",
+						},
+						Status: corev1.PersistentVolumeStatus{
+							Phase: "Available",
+						},
+					},
+				},
+			}
+
+			api.EXPECT().GetPersistentVolumes().Times(1).Return(volumes, nil)
+
+			finder := k8s.VolumeFinder{API: api, DriverNames: []string{"csi-powerstore.dellemc.com"}, Logger: logrus.New()}
+			return finder, check(hasNoError, checkExpectedOutput([]k8s.VolumeInfo{
+				{
+					Namespace:              "namespace-1",
+					PersistentVolumeClaim:  "pvc-uid",
+					PersistentVolumeStatus: "Bound",
+					VolumeClaimName:        "pvc-name",
+					PersistentVolume:       "persistent-volume-name",
+					StorageClass:           "storage-class-name",
+					Driver:                 "csi-powerstore.dellemc.com",
+					ProvisionedSize:        "16Gi",
+					VolumeHandle:           "storage-system-volume-id/127.0.0.1/protocol",
+					CreatedTime:            t1.String(),
+				},
+			})), ctrl
+		},
 		"error calling k8s": func(*testing.T) (k8s.VolumeFinder, []checkFn, *gomock.Controller) {
 			ctrl := gomock.NewController(t)
 			api := mocks.NewMockVolumeGetter(ctrl)

--- a/internal/k8s/volume_finder_test.go
+++ b/internal/k8s/volume_finder_test.go
@@ -366,16 +366,24 @@ func Test_K8sPersistentVolumeFinder(t *testing.T) {
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:              "persistent-volume-name",
+							Name:              "persistent-volume-name2",
 							CreationTimestamp: metav1.Time{Time: t1},
 						},
 						Spec: corev1.PersistentVolumeSpec{
 							Capacity: map[corev1.ResourceName]resource.Quantity{
 								v1.ResourceStorage: resource.MustParse("16Gi"),
 							},
-							PersistentVolumeSource: corev1.PersistentVolumeSource{},
-							ClaimRef:               nil,
-							StorageClassName:       "storage-class-name",
+							PersistentVolumeSource: corev1.PersistentVolumeSource{
+								CSI: &corev1.CSIPersistentVolumeSource{
+									Driver: "csi-powerstore.dellemc.com",
+									VolumeAttributes: map[string]string{
+										"arrayIP": "127.0.0.1",
+									},
+									VolumeHandle: "storage-system-volume-id/127.0.0.1/protocol",
+								},
+							},
+							ClaimRef:         nil,
+							StorageClassName: "storage-class-name",
 						},
 						Status: corev1.PersistentVolumeStatus{
 							Phase: "Available",


### PR DESCRIPTION
# Description
Added a nil check to skip processing pvs without ClaimRef. This will prevent karavi-metrics-powerscale from crashing when there are unbound pv s in clusters

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1019|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make unit test results
![image](https://github.com/dell/csm-metrics-powerstore/assets/90749010/879aea63-c20d-44ce-b016-512c57180d95)
- [x] topology test passed
![image](https://github.com/dell/csm-metrics-powerstore/assets/91597668/761da526-5a50-4acb-8e96-f60bdfdf80f6)
- [x] metrics test passed
![image](https://github.com/dell/csm-metrics-powerstore/assets/91597668/78881ea2-51bf-4aff-85be-dccff364da47)




