### PR TITLE
Add preflight required labels.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /go/src/service /go/src/$APP_NAME/$CMD_
 
 # Build the sdk image
 FROM $BASEIMAGE as final
-LABEL vendor="Dell Inc." \
+LABEL vendor="Dell Technologies" \
+      maintainer="Dell Technologies" \
       name="csm-metrics-powerstore" \
       summary="Dell Container Storage Modules (CSM) for Observability - Metrics for PowerStore" \
       description="Provides insight into storage usage and performance as it relates to the CSI (Container Storage Interface) Driver for Dell PowerStore" \
-      version="2.0.0" \
+      release="1.13.0" \
+      version="1.11.0" \
       license="Apache-2.0"
 COPY --from=builder /go/src/service /
 ENTRYPOINT ["/service"]


### PR DESCRIPTION
# Description
Added the required labels to the image container so that it can pass preflight checks.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1667 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Built image. Docker inspect shows:

{
  "architecture": "x86_64",
  "build-date": "2024-08-27T19:24:54",
  "com.redhat.component": "ubi9-micro-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "Provides insight into storage usage and performance as it relates to the CSI (Container Storage Interface) Driver for Dell PowerStore",
  "distribution-scope": "public",
  "io.buildah.version": "1.29.4",
  "io.k8s.description": "Very small image which doesn't install the package manager.",
  "io.k8s.display-name": "Ubi9-micro",
  "io.openshift.expose-services": "",
  "license": "Apache-2.0",
  "maintainer": "Dell Technologies",
  "name": "csm-metrics-powerstore",
  "release": "1.13.0",
  "summary": "Dell Container Storage Modules (CSM) for Observability - Metrics for PowerStore",
  "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.4-15",
  "vcs-ref": "cd5996c9b8b99b546584696465f8f39ec682078c",
  "vcs-type": "git",
  "vendor": "Dell Technologies",
  "version": "1.11.0"
}