### PR TITLE
Fixed reading maxPowerStoreConcurrentRequests

### DIFF
--- a/cmd/metrics-powerstore/main.go
+++ b/cmd/metrics-powerstore/main.go
@@ -296,12 +296,14 @@ func updateService(pstoreSvc *service.PowerStoreService, logger *logrus.Logger) 
 	maxPowerStoreConcurrentRequests := service.DefaultMaxPowerStoreConnections
 	maxPowerStoreConcurrentRequestsVar := viper.GetString("POWERSTORE_MAX_CONCURRENT_QUERIES")
 	if maxPowerStoreConcurrentRequestsVar != "" {
-		maxPowerStoreConcurrentRequests, err := strconv.Atoi(maxPowerStoreConcurrentRequestsVar)
+		maxConncurrentRequests, err := strconv.Atoi(maxPowerStoreConcurrentRequestsVar)
 		if err != nil {
 			logger.WithError(err).Fatal("POWERSTORE_MAX_CONCURRENT_QUERIES was not set to a valid number")
 		}
-		if maxPowerStoreConcurrentRequests <= 0 {
+		if maxConncurrentRequests <= 0 {
 			logger.WithError(err).Fatal("POWERSTORE_MAX_CONCURRENT_QUERIES value was invalid (<= 0)")
+		} else {
+			maxPowerStoreConcurrentRequests = maxConncurrentRequests
 		}
 	}
 	pstoreSvc.MaxPowerStoreConnections = maxPowerStoreConcurrentRequests

--- a/cmd/metrics-powerstore/main_test.go
+++ b/cmd/metrics-powerstore/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dell/csm-metrics-powerstore/internal/service"
+)
+
+func TestUpdateService(t *testing.T) {
+	t.Run("Default value when env var is not set", func(t *testing.T) {
+		pstoreSvc := &service.PowerStoreService{}
+		logger := logrus.New()
+
+		viper.Set("POWERSTORE_MAX_CONCURRENT_QUERIES", "")
+		updateService(pstoreSvc, logger)
+
+		assert.Equal(t, service.DefaultMaxPowerStoreConnections, pstoreSvc.MaxPowerStoreConnections)
+	})
+
+	t.Run("Valid env var value", func(t *testing.T) {
+		pstoreSvc := &service.PowerStoreService{}
+		logger := logrus.New()
+		validValue := 10
+		viper.Set("POWERSTORE_MAX_CONCURRENT_QUERIES", strconv.Itoa(validValue))
+
+		updateService(pstoreSvc, logger)
+		assert.Equal(t, validValue, pstoreSvc.MaxPowerStoreConnections)
+	})
+}


### PR DESCRIPTION
# Description
Reading POWERSTORE_MAX_CONCURRENT_QUERIES from config doesn't work. The variable is shadowed inside an `if` statement due to reduntante short hand declaration. I've added a new variable similar to the `updateTickIntervals` function which is set to `maxPowerStoreConcurrentRequests`.

# GitHub Issues
List the GitHub issues impacted by this PR:
*There are no issues in this repository*

| GitHub Issue # |
| -------------- |
| none |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Due to the *FATAL* logging in error cases, this has been tested manually.
In addition I've added two test cases for success cases.

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [ ] Yes
- [ ] No
